### PR TITLE
Add industrial_ci for package configuration testing

### DIFF
--- a/.github/workflows/industrialci.yml
+++ b/.github/workflows/industrialci.yml
@@ -1,0 +1,33 @@
+name: industrial_ci
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  schedule:
+    - cron: "0 1 * * 2" # Weekly on Tuesdays at 01:00(GMT)
+
+jobs:
+  industrial_ci:
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        env:
+          - { ROS_DISTRO: kinetic, ROS_REPO: main }
+          - { ROS_DISTRO: melodic, ROS_REPO: main }
+        experimental: [false]
+        include:
+          - env: { ROS_DISTRO: kinetic, ROS_REPO: testing }
+            experimental: true
+          - env: { ROS_DISTRO: melodic, ROS_REPO: testing }
+            experimental: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "ros-industrial/industrial_ci@master"
+        env: ${{ matrix.env }}


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

ROSパッケージの構成チェックのためにindustrial_ciを導入します。
URDFやxacroのマクロ等だけの簡単な構成ですが、package.xmlやCMakeLists.txtに問題がないかわかるので導入します。
