### PR TITLE
Fix typo to suppress warnings loading GazeboPlugin

### DIFF
--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -40,7 +40,7 @@
         <wheelAcceleration>0</wheelAcceleration>
 
         <!-- Set to true to publish /odom (nav_msgs::Odometry), defaults to true -->
-        <publishTF>$(arg tf)</publishTF>
+        <publishTf>$(arg tf)</publishTf>
         <!-- Set to true to publish transforms for the wheel links, defaults to false -->
         <publishWheelTF>$(arg tf)</publishWheelTF>
         <!-- Set to true to publish transforms for the odometry, defaults to true -->


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Gazebo起動時に以下のWARNINGが出るのでtypo修正します。
```
GazeboRosDiffDrive Plugin (ns = ) missing <publishTf>, defaults to 1
```
